### PR TITLE
Nissix plugin scope-packages on @wix/marketing-submissions-adapter

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "husky": "^1.3.1",
     "lint-staged": "^8.1.5",
     "typescript": "~3.0.1",
-    "yoshi": "^4.1.0"
+    "@wix/yoshi": "^4.1.0"
   },
   "dependencies": {
     "@wix/wix-bootstrap-ng": "latest",
@@ -43,7 +43,7 @@
     "axios": "^0.16.2",
     "ejs": "~2.5.0",
     "express": "~4.15.0",
-    "wix-debug": "^1.0.182"
+    "@wix/wix-debug": "^1.0.182"
   },
   "lint-staged": {
     "linters": {

--- a/wallaby.js
+++ b/wallaby.js
@@ -1,1 +1,1 @@
-module.exports = require('yoshi/config/wallaby-mocha');
+module.exports = require('@wix/yoshi/config/wallaby-mocha');


### PR DESCRIPTION
Hi, I'm Nissix, the automated PR bot!

Wix is moving its internal packages to the @wix scope (but still in the internal registry). Publishing new unscoped internal packages is no longer allowed, and all existing packages are moving to @wix. This means changing package names, and also all usages of those packages to their @wix scope version.

This PR is an automatic codemod that moves all of your packages to @wix scope, and changes any usages (`pacakge.json`, imports, requires, etc..) to their @wix version.

| :bangbang: | This codemod is best-effort! Meaning it may not have found and fixed all usages, but it did change your package.jsons. So go over the changes carefully and test this version carefully  |
| :--------: | :----------------------------------------------------------------------------------------------------- |

If you want to know why we don't support publishing unscoped to the internal registry, check out this article on [Dependency Confusion](https://medium.com/@alex.birsan/dependency-confusion-4a5d60fec610)

If you are unsure, need help or have questions, reach us at #wix-scope-migration

Error Log:
npx: installed 234 in 5.771s
npm WARN deprecated @zeit/webpack-asset-relocator-loader@0.8.0: "@zeit/webpack-asset-relocator-loader" is deprecated in favor of "@vercel/webpack-asset-relocator-loader".
npm WARN deprecated tslint@6.1.3: TSLint has been deprecated in favor of ESLint. Please see https://github.com/palantir/tslint/issues/4534 for more information.
npm WARN deprecated chokidar@2.1.8: Chokidar 2 will break on node v14+. Upgrade to chokidar 3 with 15x less dependencies.
npm WARN deprecated babel-eslint@10.1.0: babel-eslint is now @babel/eslint-parser. This package will no longer receive updates.
npm WARN deprecated @types/joi@17.2.3: This is a stub types definition. joi provides its own type definitions, so you do not need this installed.
npm WARN deprecated node-pre-gyp@0.15.0: Please upgrade to @mapbox/node-pre-gyp: the non-scoped node-pre-gyp package is deprecated and only the @mapbox scoped package will recieve updates in the future
npm WARN deprecated request@2.88.2: request has been deprecated, see https://github.com/request/request/issues/3142
npm WARN deprecated har-validator@5.1.5: this library is no longer supported
npm WARN deprecated node-pre-gyp@0.16.0: Please upgrade to @mapbox/node-pre-gyp: the non-scoped node-pre-gyp package is deprecated and only the @mapbox scoped package will recieve updates in the future
npm WARN deprecated mkdirp@0.5.1: Legacy versions of mkdirp are no longer supported. Please update to mkdirp 1.x. (Note that the API surface has changed to use Promises in 1.x.)
node-pre-gyp WARN Using needle for node-pre-gyp https download 
node-pre-gyp WARN Using needle for node-pre-gyp https download 
npm WARN optional SKIPPING OPTIONAL DEPENDENCY: fsevents@~2.3.1 (node_modules/yoshi-common/node_modules/chokidar/node_modules/fsevents):
npm WARN notsup SKIPPING OPTIONAL DEPENDENCY: Unsupported platform for fsevents@2.3.2: wanted {"os":"darwin","arch":"any"} (current: {"os":"linux","arch":"x64"})
npm WARN optional SKIPPING OPTIONAL DEPENDENCY: fsevents@~2.3.1 (node_modules/yoshi-webpack-utils/node_modules/watchpack/node_modules/chokidar/node_modules/fsevents):
npm WARN notsup SKIPPING OPTIONAL DEPENDENCY: Unsupported platform for fsevents@2.3.2: wanted {"os":"darwin","arch":"any"} (current: {"os":"linux","arch":"x64"})
npm WARN optional SKIPPING OPTIONAL DEPENDENCY: fsevents@~2.3.1 (node_modules/yoshi-command-lint/node_modules/chokidar/node_modules/fsevents):
npm WARN notsup SKIPPING OPTIONAL DEPENDENCY: Unsupported platform for fsevents@2.3.2: wanted {"os":"darwin","arch":"any"} (current: {"os":"linux","arch":"x64"})
npm WARN optional SKIPPING OPTIONAL DEPENDENCY: fsevents@~2.3.1 (node_modules/yoshi-flow-legacy/node_modules/chokidar/node_modules/fsevents):
npm WARN notsup SKIPPING OPTIONAL DEPENDENCY: Unsupported platform for fsevents@2.3.2: wanted {"os":"darwin","arch":"any"} (current: {"os":"linux","arch":"x64"})
npm WARN optional SKIPPING OPTIONAL DEPENDENCY: fsevents@~2.3.1 (node_modules/yoshi-config-compat/node_modules/chokidar/node_modules/fsevents):
npm WARN notsup SKIPPING OPTIONAL DEPENDENCY: Unsupported platform for fsevents@2.3.2: wanted {"os":"darwin","arch":"any"} (current: {"os":"linux","arch":"x64"})
npm WARN optional SKIPPING OPTIONAL DEPENDENCY: fsevents@~2.3.1 (node_modules/yoshi-server-tools/node_modules/chokidar/node_modules/fsevents):
npm WARN notsup SKIPPING OPTIONAL DEPENDENCY: Unsupported platform for fsevents@2.3.2: wanted {"os":"darwin","arch":"any"} (current: {"os":"linux","arch":"x64"})
npm WARN optional SKIPPING OPTIONAL DEPENDENCY: fsevents@~2.3.1 (node_modules/yoshi-flow-app/node_modules/chokidar/node_modules/fsevents):
npm WARN notsup SKIPPING OPTIONAL DEPENDENCY: Unsupported platform for fsevents@2.3.2: wanted {"os":"darwin","arch":"any"} (current: {"os":"linux","arch":"x64"})
npm WARN optional SKIPPING OPTIONAL DEPENDENCY: fsevents@~2.3.1 (node_modules/yoshi-flow-monorepo/node_modules/chokidar/node_modules/fsevents):
npm WARN notsup SKIPPING OPTIONAL DEPENDENCY: Unsupported platform for fsevents@2.3.2: wanted {"os":"darwin","arch":"any"} (current: {"os":"linux","arch":"x64"})
npm WARN optional SKIPPING OPTIONAL DEPENDENCY: fsevents@~2.3.1 (node_modules/@wix/yoshi/node_modules/chokidar/node_modules/fsevents):
npm WARN notsup SKIPPING OPTIONAL DEPENDENCY: Unsupported platform for fsevents@2.3.2: wanted {"os":"darwin","arch":"any"} (current: {"os":"linux","arch":"x64"})
npm WARN @wix/wix-bootstrap-ng@1.0.4957 requires a peer of express@>=4.17.0 but none is installed. You must install peer dependencies yourself.
npm WARN @wix/wnp-bootstrap-composer@0.1.4115 requires a peer of express@>=4.17.0 but none is installed. You must install peer dependencies yourself.
npm WARN @wix/wnp-bootstrap-proto-introspection@1.0.541 requires a peer of express@>=4.17.0 but none is installed. You must install peer dependencies yourself.
npm WARN @wix/wix-express-metering@0.1.1553 requires a peer of express@>=4.17.0 but none is installed. You must install peer dependencies yourself.
npm WARN @wix/wnp-bootstrap-management@1.0.1862 requires a peer of express@>=4.17.0 but none is installed. You must install peer dependencies yourself.
npm WARN @wix/wnp-bootstrap-express@1.0.2462 requires a peer of express@>=4.17.0 but none is installed. You must install peer dependencies yourself.
npm WARN @wix/wnp-bootstrap-rest-proto@1.0.1095 requires a peer of express@>=4.17.0 but none is installed. You must install peer dependencies yourself.
npm WARN @wix/wnp-bootstrap-rpc-server@1.0.1315 requires a peer of express@>=4.17.0 but none is installed. You must install peer dependencies yourself.
npm WARN express-async-errors@3.1.1 requires a peer of express@^4.16.2 but none is installed. You must install peer dependencies yourself.
npm WARN @wix/wix-express-proto@1.0.1163 requires a peer of express@>=4.17.0 but none is installed. You must install peer dependencies yourself.
npm WARN babel-plugin-transform-hmr-runtime@4.286.0 requires a peer of babel-core@^7.0.0-0 but none is installed. You must install peer dependencies yourself.
npm WARN react-hot-loader@4.13.0 requires a peer of react@^15.0.0 || ^16.0.0 || ^17.0.0  but none is installed. You must install peer dependencies yourself.
npm WARN react-hot-loader@4.13.0 requires a peer of react-dom@^15.0.0 || ^16.0.0 || ^17.0.0  but none is installed. You must install peer dependencies yourself.
npm WARN tslint-config-yoshi-base@4.167.0 requires a peer of prettier@^2.0.5 but none is installed. You must install peer dependencies yourself.
npm WARN tslint-plugin-wix-style-react@1.0.9 requires a peer of tslint@^5.0.0 but none is installed. You must install peer dependencies yourself.
npm WARN tslint-plugin-wix-style-react@1.0.9 requires a peer of typescript@^2.4.0 but none is installed. You must install peer dependencies yourself.
npm WARN yoshi-runtime@1.0.733 requires a peer of node-sass@^4.11.0 but none is installed. You must install peer dependencies yourself.
npm WARN tslint-react@4.1.0 requires a peer of tslint@^5.1.0 but none is installed. You must install peer dependencies yourself.
npm WARN tslint-plugin-prettier@2.3.0 requires a peer of prettier@^1.9.0 || ^2.0.0 but none is installed. You must install peer dependencies yourself.
npm WARN eslint-plugin-prettier@2.7.0 requires a peer of prettier@>= 0.11.0 but none is installed. You must install peer dependencies yourself.
npm WARN @babel/preset-typescript@7.12.7 requires a peer of @babel/core@^7.0.0-0 but none is installed. You must install peer dependencies yourself.
npm WARN graphql-tag@2.11.0 requires a peer of graphql@^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 but none is installed. You must install peer dependencies yourself.
npm WARN @babel/plugin-transform-typescript@7.13.0 requires a peer of @babel/core@^7.0.0-0 but none is installed. You must install peer dependencies yourself.
npm WARN @babel/helper-create-class-features-plugin@7.13.8 requires a peer of @babel/core@^7.0.0 but none is installed. You must install peer dependencies yourself.
npm WARN @babel/plugin-syntax-typescript@7.12.13 requires a peer of @babel/core@^7.0.0-0 but none is installed. You must install peer dependencies yourself.
npm WARN copy-webpack-plugin@5.1.2 requires a peer of webpack@^4.0.0 || ^5.0.0 but none is installed. You must install peer dependencies yourself.
npm WARN mdsvex@0.6.1 requires a peer of svelte@3.x but none is installed. You must install peer dependencies yourself.
npm WARN webpack-manifest-plugin@2.2.0 requires a peer of webpack@2 || 3 || 4 but none is installed. You must install peer dependencies yourself.
npm WARN webpackbar@4.0.0 requires a peer of webpack@^3.0.0 || ^4.0.0 but none is installed. You must install peer dependencies yourself.
npm WARN worker-loader@2.0.0 requires a peer of webpack@^3.0.0 || ^4.0.0-alpha.0 || ^4.0.0 but none is installed. You must install peer dependencies yourself.
npm WARN @babel/helper-compilation-targets@7.13.8 requires a peer of @babel/core@^7.0.0 but none is installed. You must install peer dependencies yourself.
npm WARN @babel/plugin-proposal-export-namespace-from@7.12.13 requires a peer of @babel/core@^7.0.0-0 but none is installed. You must install peer dependencies yourself.
npm WARN @babel/plugin-proposal-logical-assignment-operators@7.13.8 requires a peer of @babel/core@^7.0.0-0 but none is installed. You must install peer dependencies yourself.
npm WARN @babel/plugin-proposal-nullish-coalescing-operator@7.13.8 requires a peer of @babel/core@^7.0.0-0 but none is installed. You must install peer dependencies yourself.
npm WARN @babel/plugin-proposal-dynamic-import@7.13.8 requires a peer of @babel/core@^7.0.0-0 but none is installed. You must install peer dependencies yourself.
npm WARN @babel/plugin-syntax-dynamic-import@7.8.3 requires a peer of @babel/core@^7.0.0-0 but none is installed. You must install peer dependencies yourself.
npm WARN @babel/plugin-proposal-numeric-separator@7.12.13 requires a peer of @babel/core@^7.0.0-0 but none is installed. You must install peer dependencies yourself.
npm WARN @babel/plugin-proposal-optional-chaining@7.13.8 requires a peer of @babel/core@^7.0.0-0 but none is installed. You must install peer dependencies yourself.
npm WARN @babel/plugin-proposal-private-methods@7.13.0 requires a peer of @babel/core@^7.0.0-0 but none is installed. You must install peer dependencies yourself.
npm WARN @babel/helper-create-class-features-plugin@7.13.8 requires a peer of @babel/core@^7.0.0 but none is installed. You must install peer dependencies yourself.
npm WARN @babel/plugin-syntax-class-properties@7.12.13 requires a peer of @babel/core@^7.0.0-0 but none is installed. You must install peer dependencies yourself.
npm WARN @babel/plugin-syntax-export-namespace-from@7.8.3 requires a peer of @babel/core@^7.0.0-0 but none is installed. You must install peer dependencies yourself.
npm WARN @babel/plugin-syntax-logical-assignment-operators@7.10.4 requires a peer of @babel/core@^7.0.0-0 but none is installed. You must install peer dependencies yourself.
npm WARN @babel/plugin-syntax-numeric-separator@7.10.4 requires a peer of @babel/core@^7.0.0-0 but none is installed. You must install peer dependencies yourself.
npm WARN @babel/plugin-syntax-nullish-coalescing-operator@7.8.3 requires a peer of @babel/core@^7.0.0-0 but none is installed. You must install peer dependencies yourself.
npm WARN @babel/plugin-syntax-optional-chaining@7.8.3 requires a peer of @babel/core@^7.0.0-0 but none is installed. You must install peer dependencies yourself.
npm WARN @babel/plugin-syntax-top-level-await@7.12.13 requires a peer of @babel/core@^7.0.0-0 but none is installed. You must install peer dependencies yourself.
npm WARN @babel/plugin-transform-unicode-escapes@7.12.13 requires a peer of @babel/core@^7.0.0-0 but none is installed. You must install peer dependencies yourself.
npm WARN babel-plugin-polyfill-corejs3@0.1.7 requires a peer of @babel/core@^7.0.0-0 but none is installed. You must install peer dependencies yourself.
npm WARN babel-plugin-polyfill-corejs2@0.1.10 requires a peer of @babel/core@^7.0.0-0 but none is installed. You must install peer dependencies yourself.
npm WARN babel-plugin-polyfill-regenerator@0.1.6 requires a peer of @babel/core@^7.0.0-0 but none is installed. You must install peer dependencies yourself.
npm WARN @babel/preset-modules@0.1.4 requires a peer of @babel/core@^7.0.0-0 but none is installed. You must install peer dependencies yourself.
npm WARN @babel/helper-create-regexp-features-plugin@7.12.17 requires a peer of @babel/core@^7.0.0 but none is installed. You must install peer dependencies yourself.
npm WARN @babel/helper-define-polyfill-provider@0.1.5 requires a peer of @babel/core@^7.4.0-0 but none is installed. You must install peer dependencies yourself.
npm WARN @babel/plugin-transform-react-jsx-development@7.12.17 requires a peer of @babel/core@^7.0.0-0 but none is installed. You must install peer dependencies yourself.
npm WARN @babel/plugin-transform-react-jsx@7.12.17 requires a peer of @babel/core@^7.0.0-0 but none is installed. You must install peer dependencies yourself.
npm WARN @babel/plugin-syntax-jsx@7.12.13 requires a peer of @babel/core@^7.0.0-0 but none is installed. You must install peer dependencies yourself.
npm WARN @babel/plugin-transform-react-pure-annotations@7.12.1 requires a peer of @babel/core@^7.0.0-0 but none is installed. You must install peer dependencies yourself.
npm WARN tslint-config-yoshi@4.178.0 requires a peer of tslint-react-hooks@^2.1.0 but none is installed. You must install peer dependencies yourself.




Output Log:
Migrating package "@wix/marketing-submissions-adapter" in .


## Migration from non scope to @wix/scoped packages
> /tmp/40c15a12d162354f12c5602d818db441

#### rename package.json dependencies/dev/bundled/peer/optional, jest & eslintConfig
```
package.json
```

#### replace import/require in js/ts files
```
wallaby.js
```

> v8-profiler-node8@6.3.0 preinstall /tmp/40c15a12d162354f12c5602d818db441/node_modules/v8-profiler-node8
> node -e 'process.exit(0)'


> dtrace-provider@0.8.8 install /tmp/40c15a12d162354f12c5602d818db441/node_modules/dtrace-provider
> node-gyp rebuild || node suppress-error.js

make: Entering directory '/tmp/40c15a12d162354f12c5602d818db441/node_modules/dtrace-provider/build'
  TOUCH Release/obj.target/DTraceProviderStub.stamp
make: Leaving directory '/tmp/40c15a12d162354f12c5602d818db441/node_modules/dtrace-provider/build'

> @newrelic/native-metrics@6.0.0 install /tmp/40c15a12d162354f12c5602d818db441/node_modules/@newrelic/native-metrics
> node ./lib/pre-build.js install native_metrics

============================================================================
Attempting install in native-metrics module. Please note that this is an
OPTIONAL dependency, and any resultant errors in this process will not
affect the general performance of the New Relic agent, but event loop and
garbage collection metrics will not be collected.
============================================================================

> /usr/local/bin/node /usr/local/lib/node_modules/npm/node_modules/node-gyp/bin/node-gyp.js clean configure
> /usr/local/bin/node /usr/local/lib/node_modules/npm/node_modules/node-gyp/bin/node-gyp.js build -j 8 native_metrics
make: Entering directory '/tmp/40c15a12d162354f12c5602d818db441/node_modules/@newrelic/native-metrics/build'
  CXX(target) Release/obj.target/native_metrics/src/native_metrics.o
  CXX(target) Release/obj.target/native_metrics/src/LoopChecker.o
  CXX(target) Release/obj.target/native_metrics/src/RUsageMeter.o
  CXX(target) Release/obj.target/native_metrics/src/GCBinder.o
  SOLINK_MODULE(target) Release/obj.target/native_metrics.node
  COPY Release/native_metrics.node
make: Leaving directory '/tmp/40c15a12d162354f12c5602d818db441/node_modules/@newrelic/native-metrics/build'
install successful: _newrelic_native_metrics-6_0_0-native_metrics-72-linux-x64

> grpc@1.24.4 install /tmp/40c15a12d162354f12c5602d818db441/node_modules/grpc
> node-pre-gyp install --fallback-to-build --library=static_library

[grpc] Success: "/tmp/40c15a12d162354f12c5602d818db441/node_modules/grpc/src/node/extension_binary/node-v72-linux-x64-glibc/grpc_node.node" is installed via remote

> v8-profiler-node8@6.3.0 install /tmp/40c15a12d162354f12c5602d818db441/node_modules/v8-profiler-node8
> node-pre-gyp install --fallback-to-build

[v8-profiler-node8] Success: "/tmp/40c15a12d162354f12c5602d818db441/node_modules/v8-profiler-node8/build/binding/Release/node-v72-linux-x64/profiler.node" is installed via remote

> protobufjs@6.10.2 postinstall /tmp/40c15a12d162354f12c5602d818db441/node_modules/protobufjs
> node scripts/postinstall


> @wix/wnp-bootstrap-aspects@1.0.1165 postinstall /tmp/40c15a12d162354f12c5602d818db441/node_modules/@wix/wnp-bootstrap-aspects
> copy-config-templates

copy-config-templates(@wix/wnp-bootstrap-aspects): NODE_ENV='production', copying configs from '/tmp/40c15a12d162354f12c5602d818db441/node_modules/@wix/wnp-bootstrap-aspects/templates' to '/templates'

> @wix/wnp-bootstrap-consent-policy@1.0.79 postinstall /tmp/40c15a12d162354f12c5602d818db441/node_modules/@wix/wnp-bootstrap-consent-policy
> copy-config-templates

copy-config-templates(@wix/wnp-bootstrap-consent-policy): NODE_ENV='production', copying configs from '/tmp/40c15a12d162354f12c5602d818db441/node_modules/@wix/wnp-bootstrap-consent-policy/templates' to '/templates'

> @wix/wnp-bootstrap-framework-config@1.0.27 postinstall /tmp/40c15a12d162354f12c5602d818db441/node_modules/@wix/wnp-bootstrap-framework-config
> copy-config-templates

copy-config-templates(@wix/wnp-bootstrap-framework-config): NODE_ENV='production', copying configs from '/tmp/40c15a12d162354f12c5602d818db441/node_modules/@wix/wnp-bootstrap-framework-config/templates' to '/templates'

> @wix/wnp-bootstrap-petri@1.0.2081 postinstall /tmp/40c15a12d162354f12c5602d818db441/node_modules/@wix/wnp-bootstrap-petri
> copy-config-templates

copy-config-templates(@wix/wnp-bootstrap-petri): NODE_ENV='production', copying configs from '/tmp/40c15a12d162354f12c5602d818db441/node_modules/@wix/wnp-bootstrap-petri/templates' to '/templates'

> @wix/wnp-bootstrap-session@1.0.1724 postinstall /tmp/40c15a12d162354f12c5602d818db441/node_modules/@wix/wnp-bootstrap-session
> copy-config-templates

copy-config-templates(@wix/wnp-bootstrap-session): NODE_ENV='production', copying configs from '/tmp/40c15a12d162354f12c5602d818db441/node_modules/@wix/wnp-bootstrap-session/templates' to '/templates'

> @wix/wnp-bootstrap-statsd@1.0.1653 postinstall /tmp/40c15a12d162354f12c5602d818db441/node_modules/@wix/wnp-bootstrap-statsd
> copy-config-templates

copy-config-templates(@wix/wnp-bootstrap-statsd): NODE_ENV='production', copying configs from '/tmp/40c15a12d162354f12c5602d818db441/node_modules/@wix/wnp-bootstrap-statsd/templates' to '/templates'

> @wix/wnp-bootstrap-tracing@1.0.976 postinstall /tmp/40c15a12d162354f12c5602d818db441/node_modules/@wix/wnp-bootstrap-tracing
> copy-config-templates

copy-config-templates(@wix/wnp-bootstrap-tracing): NODE_ENV='production', copying configs from '/tmp/40c15a12d162354f12c5602d818db441/node_modules/@wix/wnp-bootstrap-tracing/templates' to '/templates'

> @wix/wnp-identities-token@1.0.4 postinstall /tmp/40c15a12d162354f12c5602d818db441/node_modules/@wix/wnp-identities-token
> copy-config-templates

copy-config-templates(@wix/wnp-identities-token): NODE_ENV='production', copying configs from '/tmp/40c15a12d162354f12c5602d818db441/node_modules/@wix/wnp-identities-token/templates' to '/templates'

> @wix/wnp-bootstrap-petri-specs@0.1.1747 postinstall /tmp/40c15a12d162354f12c5602d818db441/node_modules/@wix/wnp-bootstrap-petri-specs
> copy-config-templates

copy-config-templates(@wix/wnp-bootstrap-petri-specs): NODE_ENV='production', copying configs from '/tmp/40c15a12d162354f12c5602d818db441/node_modules/@wix/wnp-bootstrap-petri-specs/templates' to '/templates'

> @wix/wnp-bootstrap-rpc-signing@1.0.1086 postinstall /tmp/40c15a12d162354f12c5602d818db441/node_modules/@wix/wnp-bootstrap-rpc-signing
> copy-config-templates

copy-config-templates(@wix/wnp-bootstrap-rpc-signing): NODE_ENV='production', copying configs from '/tmp/40c15a12d162354f12c5602d818db441/node_modules/@wix/wnp-bootstrap-rpc-signing/templates' to '/templates'

> @wix/wnp-bootstrap-express@1.0.2462 postinstall /tmp/40c15a12d162354f12c5602d818db441/node_modules/@wix/wnp-bootstrap-express
> copy-config-templates

copy-config-templates(@wix/wnp-bootstrap-express): NODE_ENV='production', copying configs from '/tmp/40c15a12d162354f12c5602d818db441/node_modules/@wix/wnp-bootstrap-express/templates' to '/templates'

> @wix/wnp-bootstrap-grpc@1.0.1033 postinstall /tmp/40c15a12d162354f12c5602d818db441/node_modules/@wix/wnp-bootstrap-grpc
> copy-config-templates

copy-config-templates(@wix/wnp-bootstrap-grpc): NODE_ENV='production', copying configs from '/tmp/40c15a12d162354f12c5602d818db441/node_modules/@wix/wnp-bootstrap-grpc/templates' to '/templates'

> @wix/wnp-bootstrap-composer@0.1.4115 postinstall /tmp/40c15a12d162354f12c5602d818db441/node_modules/@wix/wnp-bootstrap-composer
> copy-config-templates

copy-config-templates(@wix/wnp-bootstrap-composer): NODE_ENV='production', copying configs from '/tmp/40c15a12d162354f12c5602d818db441/node_modules/@wix/wnp-bootstrap-composer/templates' to '/templates'
added 617 packages from 457 contributors and audited 4629 packages in 95.644s

8 packages are looking for funding
  run `npm fund` for details

found 370147 vulnerabilities (271725 low, 193 moderate, 98218 high, 11 critical)
  run `npm audit fix` to fix them, or `npm audit` for details

